### PR TITLE
fix(security): require user confirmation before opening browser for Entra reauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to the "Azure DevOps Integration" extension will be document
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [2.2.0] - 2025-11-12
+
+### Added
+
+- enhance connection deletion with cache clearing and persistence
+
+### Fixed
+
+- restore missing release automation scripts (#89)
+
+### Other
+
+- Issue with connections command triggering (#86)
+- Troubleshooting connection and device code flow (#85)
+
+
 ## [2.0.9] - 2025-11-10
 
 ### Fixed

--- a/docs/ValidationChecklist.md
+++ b/docs/ValidationChecklist.md
@@ -240,6 +240,7 @@ This checklist ensures the Azure DevOps Integration Extension meets all quality,
 - [x] Authentication errors are handled properly
 - [x] Entra token expiration triggers interactive re-auth (no legacy refresh path)
 - [x] Status bar shows "Connecting..." during retries (no premature failure)
+- [x] Entra ID reauth requires user confirmation before browser opens (security fix: prevents automatic browser opening)
 
 ### Input Validation
 

--- a/media/webview/main.css
+++ b/media/webview/main.css
@@ -1,4 +1,4 @@
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/Settings.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/Settings.esbuild-svelte-fake-css */
 .settings.svelte-1k6z38r {
   display: flex;
   flex-direction: column;
@@ -84,7 +84,7 @@ button.danger.svelte-1k6z38r:hover {
   border-top: 1px solid var(--vscode-panel-border);
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/ConnectionTabs.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/ConnectionTabs.esbuild-svelte-fake-css */
 .tab-bar.svelte-2w6d2o {
   display: flex;
   gap: 0.25rem;
@@ -150,7 +150,7 @@ button.danger.svelte-1k6z38r:hover {
   display: none;
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/Dropdown.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/Dropdown.esbuild-svelte-fake-css */
 .custom-dropdown.svelte-y8wbtj {
   position: relative;
   display: inline-block;
@@ -232,7 +232,7 @@ button.danger.svelte-1k6z38r:hover {
   color: var(--vscode-list-focusForeground, var(--vscode-list-hoverForeground));
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/ErrorBanner.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/ErrorBanner.esbuild-svelte-fake-css */
 .error-banner.svelte-1ju6edo {
   display: flex;
   align-items: center;
@@ -300,7 +300,7 @@ button.danger.svelte-1k6z38r:hover {
   background: var(--vscode-list-hoverBackground);
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/EmptyState.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/EmptyState.esbuild-svelte-fake-css */
 .empty-state.svelte-qlco7a {
   display: flex;
   align-items: center;
@@ -346,7 +346,7 @@ button.danger.svelte-1k6z38r:hover {
   background: var(--vscode-button-hoverBackground);
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/WorkItemList.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/WorkItemList.esbuild-svelte-fake-css */
 .work-item-list.svelte-1uil3z2 {
   display: flex;
   flex-direction: column;
@@ -658,7 +658,7 @@ button.svelte-1uil3z2:hover {
   line-height: 1;
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/KanbanBoard.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/KanbanBoard.esbuild-svelte-fake-css */
 .kanban-board.svelte-j9p4i1 {
   display: flex;
   flex-direction: column;
@@ -817,7 +817,7 @@ h3.svelte-j9p4i1 {
   color: var(--vscode-descriptionForeground);
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/ConnectionStatus.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/ConnectionStatus.esbuild-svelte-fake-css */
 .connection-status.svelte-ky1zja {
   display: flex;
   align-items: center;
@@ -854,7 +854,7 @@ h3.svelte-j9p4i1 {
   font-size: 0.75rem;
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/StatusBar.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/StatusBar.esbuild-svelte-fake-css */
 .status-bar.svelte-1764dnv {
   display: flex;
   gap: 1rem;
@@ -887,7 +887,7 @@ h3.svelte-j9p4i1 {
   border-radius: 3px;
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/ConnectionView.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/ConnectionView.esbuild-svelte-fake-css */
 .connection-view.svelte-5unw23 {
   display: none;
 }
@@ -900,13 +900,13 @@ h3.svelte-j9p4i1 {
   gap: 0.75rem;
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/ConnectionViews.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/ConnectionViews.esbuild-svelte-fake-css */
 .connection-views.svelte-19sc4ta {
   display: flex;
   flex-direction: column;
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/AuthReminder.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/AuthReminder.esbuild-svelte-fake-css */
 .auth-reminder-banner.svelte-cv3w9g {
   display: flex;
   align-items: flex-start;
@@ -1027,7 +1027,7 @@ div.auth-message.svelte-cv3w9g {
   opacity: 1;
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/components/WebviewHeader.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/components/WebviewHeader.esbuild-svelte-fake-css */
 .webview-header.svelte-1bw0sfy {
   display: flex;
   align-items: center;
@@ -1088,7 +1088,7 @@ div.auth-message.svelte-cv3w9g {
   }
 }
 
-/* fakecss:C:/Users/kayod/.cursor/worktrees/azuredevops-integration-extension/RbIGN/src/webview/App.esbuild-svelte-fake-css */
+/* fakecss:C:/Projects/azuredevops-integration-extension/src/webview/App.esbuild-svelte-fake-css */
 main.svelte-db2r4i {
   padding: 1rem;
   font-family: var(--vscode-font-family, sans-serif);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azuredevops-integration-extension",
-  "version": "2.0.9",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azuredevops-integration-extension",
-      "version": "2.0.9",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azuredevops-integration-extension",
   "displayName": "Azure DevOps Integration for VS Code",
   "description": "Integrate Azure DevOps work items, time tracking, and Git workflows directly in VS Code. Manage tasks, track time, create branches, and submit pull requests without leaving your editor.",
-  "version": "2.0.9",
+  "version": "2.2.0",
   "type": "module",
   "publisher": "PluresLLC",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Security Fix

This PR fixes a security and trust issue where the browser would automatically open when Entra ID required reauthentication, without user confirmation.

### Problem
- Browser opened automatically when Entra ID token expired
- Security/trust issue - users had no control over when authentication happened
- UX issue - with multiple connections, users couldn't tell which connection needed reauth

### Solution
- Changed \TOKEN_EXPIRED\ handler to transition to \AUTH_FAILED\ state instead of automatically triggering interactive auth
- User must now click 'Re-authenticate' button before browser opens
- Application machine is notified to update connection health and show auth reminder UI
- User can see which connection needs reauth before browser opens

### Changes
- Modified \connectionMachine.ts\ to transition to \AUTH_FAILED\ for Entra token expiration
- Added notification to application machine for Entra auth failures
- Updated ValidationChecklist.md

### Expected Version
After merge, this will automatically bump to version **2.2.1** (patch bump for \ix:\ commit) and publish to marketplace.