### PR TITLE
fix(ci): restore green main (lockfile + lint)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1007,5 +1007,6 @@
     "*.{json,md}": [
       "npm run format:staged"
     ]
-  }
+  },
+  "packageManager": "npm@10.9.2"
 }

--- a/src/activation.ts
+++ b/src/activation.ts
@@ -134,7 +134,7 @@ let lastStateSignature: string | undefined = undefined;
 let lastResetAuthTime = 0;
 const RESET_AUTH_DEBOUNCE_MS = 2000; // 2 seconds
 let provider: WorkItemsProvider | undefined;
-let sessionTelemetry: SessionTelemetryManager | undefined;
+const sessionTelemetry: SessionTelemetryManager | undefined = undefined;
 let client: AzureDevOpsIntClient | undefined;
 let statusBarItem: vscode.StatusBarItem | undefined;
 let authStatusBarItem: vscode.StatusBarItem | undefined;

--- a/src/azureClient.ts
+++ b/src/azureClient.ts
@@ -1021,7 +1021,8 @@ export class AzureDevOpsIntClient {
               if (this._isTooManyResultsError(retryErr)) {
                 throw new Error(
                   `Query "${query}" returns too many work items (>20,000). ` +
-                    `Try filtering by a specific area path, iteration, or work item type to narrow results.`
+                    `Try filtering by a specific area path, iteration, or work item type to narrow results.`,
+                  { cause: retryErr }
                 );
               }
               throw retryErr;
@@ -1225,7 +1226,7 @@ export class AzureDevOpsIntClient {
         }
 
         // Re-throw with detailed message instead of silently returning []
-        throw new Error(errorMessage);
+        throw new Error(errorMessage, { cause: err });
       }
     });
   }

--- a/src/azureDevOpsUrlParser.ts
+++ b/src/azureDevOpsUrlParser.ts
@@ -239,9 +239,9 @@ export function parseAzureDevOpsUrl(url: string): ParsedAzureDevOpsUrl {
   const isVisualStudio =
     host.endsWith('.visualstudio.com') || host.endsWith('.vsrm.visualstudio.com');
 
-  let organization = '';
-  let project = '';
-  let baseUrl = '';
+  let organization: string;
+  let project: string;
+  let baseUrl: string;
   let isSimplifiedOnPrem = false;
 
   if (isCloudRoot) {

--- a/src/debugging/historyExport.ts
+++ b/src/debugging/historyExport.ts
@@ -102,7 +102,7 @@ export function importHistoryFromJSON(json: string): void {
     const exported = JSON.parse(json) as ExportedHistory;
     importHistory(exported);
   } catch (error) {
-    throw new Error(`Failed to parse history JSON: ${error}`);
+    throw new Error(`Failed to parse history JSON: ${error}`, { cause: error });
   }
 }
 

--- a/src/logging/TraceLogger.ts
+++ b/src/logging/TraceLogger.ts
@@ -401,7 +401,7 @@ export class TraceLogger {
 
       return session.id;
     } catch (error) {
-      throw new Error(`Failed to import session: ${error}`);
+      throw new Error(`Failed to import session: ${error}`, { cause: error });
     }
   }
 


### PR DESCRIPTION
Restores a green main to unblock stuck dependabot PRs.

## Root causes
1. **Package-manager misdetection.** The reusable CI (plures/.github ci-reusable.yml) greps the whole repo for the workspace: protocol to auto-detect pnpm. The vendored .github/architectural-discipline-package/packages/* package.json files declare workspace:* deps, so the repo was detected as pnpm and ran pnpm install --frozen-lockfile -> ERR_PNPM_NO_LOCKFILE (this repo is npm; only package-lock.json exists).
2. **Real lint errors on main** from custom/core ESLint rules.

## Fixes
- Add packageManager: npm@10.9.2 to root package.json. This is the reusable's highest-priority detection signal (packageManager field), so it correctly selects npm and wins over the workspace: grep. No new pattern invented — this is the reusable's intended config input.
- no-unassigned-vars: src/activation.ts sessionTelemetry let -> const = undefined (was never assigned; still an intentionally-optional field in commandContext).
- preserve-caught-error: add { cause } to throws in azureClient.ts (x2), debugging/historyExport.ts, logging/TraceLogger.ts.
- no-useless-assignment: azureDevOpsUrlParser.ts drop dead '' initializers (all branches assign-or-return).

Verification via CI (this environment's local npm registry proxy 404s on public tarballs + node_modules is committed, so a clean local install isn't possible here — CI's linux/public-registry run is the ground truth).