### PR TITLE
fix: bump engines.vscode to match @types/vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.107.0"
+    "vscode": "^1.125.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
vsce publish has been failing on every release: '@types/vscode ^1.125.0 greater than engines.vscode ^1.107.0'. Bumps the declared minimum VS Code engine version to match the installed @types/vscode. Found while verifying the v3.2.0 forced release (run 30569382979).