### PR TITLE
fix(ci): override frontend_install/build with npm for Tauri installer builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,6 @@ jobs:
     with:
       bump: ${{ inputs.bump || '' }}
       target_version: ${{ inputs.target_version || '' }}
+      frontend_install: cd apps/app-desktop && npm install
+      frontend_build: cd apps/app-desktop && npm run build
     secrets: inherit


### PR DESCRIPTION
The shared tauri-release-reusable.yml hardcoded a pnpm install + pnpm cache with no override. This repo uses npm (packageManager npm@10.9.2, package-lock.json), so the windows/nsis+msi installer build always failed with 'Invalid packageManager field in package.json'. Requires the frontend_install/frontend_build passthrough added in plures/.github (release-reusable.yml -> build-installers).