### PR TITLE
fix(app-desktop): downgrade typescript to satisfy svelte-check peer range

### DIFF
--- a/apps/app-desktop/package.json
+++ b/apps/app-desktop/package.json
@@ -36,7 +36,7 @@
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "svelte-preprocess": "^6.0.5",
-    "typescript": "~7.0.2",
+    "typescript": "^5.9.3",
     "vite": "^8.1.5"
   }
 }


### PR DESCRIPTION
svelte-check@4.7.4 requires typescript ^5.0.0 || ^6.0.0. typescript ~7.0.2 broke npm install (ERESOLVE) for the Tauri desktop app's plain npm install (no --legacy-peer-deps), which is what blocks the windows/nsis+msi installer build.