### PR TITLE
diag: verbose npm install log (temporary)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       bump: ${{ inputs.bump || '' }}
       target_version: ${{ inputs.target_version || '' }}
-      frontend_install: cd apps/app-desktop && npm install
+      frontend_install: cd apps/app-desktop && (npm install || (Get-ChildItem "C:\npm\cache\_logs\*.log" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content -Tail 80; exit 1))
       frontend_build: cd apps/app-desktop && npm run build
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       bump: ${{ inputs.bump || '' }}
       target_version: ${{ inputs.target_version || '' }}
-      frontend_install: cd apps/app-desktop && (npm install || (Get-ChildItem "C:\npm\cache\_logs\*.log" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content -Tail 80; exit 1))
+      frontend_install: cd apps/app-desktop && npm install --loglevel=verbose
       frontend_build: cd apps/app-desktop && npm run build
     secrets: inherit


### PR DESCRIPTION
Follow-up to #278 which had a pwsh parse error in the diagnostic fallback. Simpler: just run npm install --loglevel=verbose so the actual error surfaces in the main log.