### PR TITLE
fix(app-desktop): pin @plures/praxis to 2.4.39 (last known-good, unblocks Windows installer)

### DIFF
--- a/apps/app-desktop/package.json
+++ b/apps/app-desktop/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@plures/praxis": "^2.5.8",
+    "@plures/praxis": "2.4.39",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2",


### PR DESCRIPTION
## What

Pins `apps/app-desktop`'s `@plures/praxis` dependency to exact `2.4.39` (last known-good, pre-workspace-protocol version), as a stopgap for the Windows nsis+msi installer build failure.

## Root cause (confirmed, not the earlier lockfile theory)

`@plures/praxis@2.5.8` (latest actually published on public npm - verified directly via `unpkg.com`, bypassing this devbox's broken direct TLS to registry.npmjs.org) declares:

```json
"@plures/praxis-core": "workspace:*"
```

npm's arborist cannot resolve `workspace:*` outside a monorepo context. `npm install` fails silently with `EUNSUPPORTEDPROTOCOL` buried in npm's own debug log (not visible in redirected stdout/verbose console output, which is why this took multiple investigation passes to actually surface).

**Correction to an earlier assumption this session:** `@plures/praxis@2.8.0`'s release workflow reports a green `publish-npm` job, but that version was never actually published to the public npm registry - `unpkg.com` still resolves `latest` to `2.5.8`. A green CI publish job is not proof of what's actually live on the registry.

## Fix

Exact-pinned (not `^2.4.39`) to prevent npm from re-resolving to a broken minor/patch in the future.

## Verification

- `radix__praxis-evaluate` (code_review phase): 0 violations, 43 constraints evaluated.
- Real fix (making `plures/praxis`'s publish pipeline resolve `workspace:*` before publish, and verifying the published package post-publish rather than trusting the publish command's exit code) still needed upstream - tracked separately.
- This PR alone should unblock the Windows `nsis+msi` installer job; will trigger a real release run after merge to confirm.

Closes/supersedes the investigation in #280.
