### PR TITLE
chore: add CODEOWNERS baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for unowned paths
+* @kbristol


### PR DESCRIPTION
Adds .github/CODEOWNERS with a default owner (@kbristol), matching the baseline already present in plures/openclaw. Low-risk, mechanical, part of the org-wide hygiene refactor (approved decision 5: org-wide branch-protection/policy baseline). No CI/behavior change.